### PR TITLE
Make timer countdown in draw-card component when turn starts

### DIFF
--- a/ui/src/components/CardInput.js
+++ b/ui/src/components/CardInput.js
@@ -35,22 +35,24 @@ class CardInput extends Component {
 
     onSubmit(e) {
         e.preventDefault();
-        axios({
-            method: 'post',
-            url: '/v1/api/game/' + this.props.gameId + '/card',
-            timeout: 4000,    // 4 seconds timeout
-            data: {
-                value: capitalize(this.state.card),
-            }
-          })
-        .then((result) => {
-            console.log(result)
-            this.setState({card: ""})
-            this.getCardCount();
-        })
-        .catch(function (error) {
-            console.log(error);
-        });
+        if (this.state.card != "") {
+            axios({
+                method: 'post',
+                url: '/v1/api/game/' + this.props.gameId + '/card',
+                timeout: 4000,    // 4 seconds timeout
+                data: {
+                    value: capitalize(this.state.card),
+                }
+              })
+            .then((result) => {
+                console.log(result)
+                this.setState({card: ""})
+                this.getCardCount();
+            })
+            .catch(function (error) {
+                console.log(error);
+            });
+        }
       }
 
     render() {

--- a/ui/src/components/DrawCard.css
+++ b/ui/src/components/DrawCard.css
@@ -15,6 +15,7 @@
     width: 80%;
     max-width: 350px;
     margin: auto;
+    min-height: 70px;
 }
 
 .card-value {

--- a/ui/src/components/DrawCard.js
+++ b/ui/src/components/DrawCard.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import Timer from './Timer';
 import axios from 'axios';
 
 import './DrawCard.css';
@@ -10,7 +11,6 @@ class DrawCard extends Component {
         this.state = {
             id: "",
             card: "",
-            team_1_turn: false,
             team1: "Team 1",
             team2: "Team 2",
             showCard: false,
@@ -32,7 +32,6 @@ class DrawCard extends Component {
         .then((response) => {
           // On page load find current team in play
           this.setState({
-              team_1_turn: response.data.result[0].team_1_turn,
               team1: response.data.result[0].teams.team_1.name,
               team2: response.data.result[0].teams.team_2.name
             })
@@ -44,13 +43,12 @@ class DrawCard extends Component {
 
     endTurn() {
         this.setState({showCard: false});
-        this.setState({team_1_turn: !this.state.team_1_turn});
         this.props.nextTurn();
     }
 
     endRound() {
-        this.props.nextRound();
         this.setState({showNextRound: false})
+        this.props.nextRound();
     }
 
     markDone() {
@@ -106,24 +104,33 @@ class DrawCard extends Component {
     }
 
     render() {
-        const team = this.state.team_1_turn ? this.state.team1 : this.state.team2;
-        const color = this.state.team_1_turn ?  "rgb(242, 85, 119, .7)":  "rgb(46, 221, 204, .7)";
+        const team = this.props.team_1_turn ? this.state.team1 : this.state.team2;
+        const color = this.props.team_1_turn ?  "rgb(242, 85, 119, .7)":  "rgb(46, 221, 204, .7)";
         return (
         <div className="draw-card">
-            <button className="start" onClick={this.drawCard}>Start Turn</button>
-            <button className="stop" onClick={this.endTurn}>End Turn</button>
 
             { this.state.showCard ?
-                <Card
-                    card={this.state.card}
-                    showSkip={this.state.showSkip}
-                    doneHandler={this.markDone}
-                    drawHandler={this.drawCard}
-                /> :
-                <PlaceHolder
-                    team={team}
-                    color={color}
-                />
+                <div>
+                    <div className="actions">
+                        <Timer timesUpHandler={this.endTurn}/>
+                    </div>
+                    <Card
+                        card={this.state.card}
+                        showSkip={this.state.showSkip}
+                        doneHandler={this.markDone}
+                        drawHandler={this.drawCard}
+                    />
+                </div>:
+                <div>
+                    <div className="actions">
+                        <button onClick={this.drawCard}>Start Turn</button>
+                        <button onClick={this.endTurn}>End Turn</button>
+                    </div>
+                    <PlaceHolder
+                        team={team}
+                        color={color}
+                    />
+                </div>
             }
             <NextRound
                 active={this.state.showNextRound}

--- a/ui/src/components/NewGame.css
+++ b/ui/src/components/NewGame.css
@@ -21,3 +21,30 @@ button {
     background-color: #F4F7B4;
     color: rgb(27, 27, 27);
   }
+
+.team-input {
+    width: 30% !important;
+    min-width: 100px;
+    padding: 12px 20px;
+    box-sizing: border-box;
+    font-size: 16px;
+    margin: 2%;
+}
+
+.pink {
+  border: 3px solid#F25577;
+}
+
+.blue {
+  border: 3px solid #2EDDCB;
+}
+
+.pink:focus {
+    background-color: rgb(243, 101, 131);
+    color: white;
+}
+
+.blue:focus {
+  background-color: rgb(129, 236, 226);
+  color: rgb(27, 27, 27);
+}

--- a/ui/src/components/NewGame.js
+++ b/ui/src/components/NewGame.js
@@ -58,6 +58,7 @@ class NewGame extends Component {
             <div className="card-form">
                 <form onSubmit={this.onSubmit}>
                     <input
+                        className="team-input pink"
                         type="text"
                         name="team1"
                         placeholder="Team 1 Name"
@@ -67,6 +68,7 @@ class NewGame extends Component {
                         onChange={this.onChange}
                     />
                     <input
+                        className="team-input blue"
                         type="text"
                         name="team2"
                         placeholder="Team 2 Name"

--- a/ui/src/components/Timer.css
+++ b/ui/src/components/Timer.css
@@ -1,0 +1,13 @@
+.timer {
+    margin: 3% auto;
+    width: 80px;
+    padding: 8px 15px;
+    background-color:#5F6167;
+    border-radius: 5%;
+    color: white;
+    font-size: 20px;
+    font-weight: bold;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+    

--- a/ui/src/components/Timer.js
+++ b/ui/src/components/Timer.js
@@ -1,0 +1,54 @@
+import React, { Component } from 'react';
+import './Timer.css'
+
+class Timer extends Component {
+
+    constructor() {
+        super();
+        this.state = {
+            minutes: 0,
+            seconds: 45,
+        }
+    }
+
+    componentDidMount() {
+        this.myInterval = setInterval(() => {
+            const { seconds, minutes } = this.state
+
+            if (seconds > 0) {
+                this.setState(({ seconds }) => ({
+                    seconds: seconds - 1
+                }))
+            }
+            if (seconds === 0) {
+                if (minutes === 0) {
+                    this.props.timesUpHandler()
+                    clearInterval(this.myInterval)
+                } else {
+                    this.setState(({ minutes }) => ({
+                        minutes: minutes - 1,
+                        seconds: 59
+                    }))
+                }
+            } 
+        }, 1000)
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.myInterval)
+    }
+
+    render() {
+        const { minutes, seconds } = this.state
+        return (
+            <div>
+                { minutes + seconds === 0
+                    ? <p></p>
+                    : <div className="timer">{minutes}:{seconds < 10 ? `0${seconds}` : seconds}</div>
+                }
+            </div>
+        )
+    }
+}
+
+export default Timer

--- a/ui/src/pages/Game.js
+++ b/ui/src/pages/Game.js
@@ -107,6 +107,7 @@ class GamePage extends Component {
             <RoundTracker round={this.state.round}/>
             <DrawCard
               gameId={gameId}
+              team_1_turn={this.state.team_1_turn}
               nextRound={this.startGame}
               nextTurn={this.nextTurn}
             />


### PR DESCRIPTION
I added a little timer component which will start counting down from 45 seconds when a turn starts and will trigger the end of the turn when the timer ends... we might want to handle that differently (like let the player click "Got It" on their final card before ending the turn rather than just abruptly ending...) But this works for now!
<img width="1072" alt="Screen Shot 2020-05-10 at 10 52 13 AM" src="https://user-images.githubusercontent.com/26209740/81496079-d7286380-92ac-11ea-9ae7-cdb900cbc6c2.png">

Other small changes in this PR:
- Rely on state in parent `GamePage` component to track which team's turn it is rather than also track inside `DrawCard` component (potential to fall out of sync)
- If card input is blank don't submit entry to backend
- Format input for team names to show corresponding color