### PR TITLE
Format all go files with gofmt

### DIFF
--- a/cmd/go-fishbowl/main.go
+++ b/cmd/go-fishbowl/main.go
@@ -1,31 +1,31 @@
 package main
 
 import (
-    "net/http"
 	"log"
+	"net/http"
 
 	"github.com/go-redis/redis"
 
 	"github.com/tifmoe/go-fishbowl/src/api"
-	"github.com/tifmoe/go-fishbowl/src/service"
 	"github.com/tifmoe/go-fishbowl/src/repository"
+	"github.com/tifmoe/go-fishbowl/src/service"
 )
 
 func main() {
 
 	var (
-		appPort 	= api.GetEnv("PORT", "8080")
-		redisHost     	= api.GetEnv("REDIS_HOST", "localhost")
-		redisPort     	= api.GetEnv("REDIS_PORT", "6379")
-		redisPassword 	= api.GetEnv("REDIS_PASSWORD", "")
-		maxCards 	= api.GetIntEnv("MAX_CARDS", 10)
+		appPort       = api.GetEnv("PORT", "8080")
+		redisHost     = api.GetEnv("REDIS_HOST", "localhost")
+		redisPort     = api.GetEnv("REDIS_PORT", "6379")
+		redisPassword = api.GetEnv("REDIS_PASSWORD", "")
+		maxCards      = api.GetIntEnv("MAX_CARDS", 10)
 	)
 
 	// Establish redis connection
 	client := redis.NewClient(&redis.Options{
-		Addr: redisHost + ":" + redisPort,
+		Addr:     redisHost + ":" + redisPort,
 		Password: redisPassword,
-		DB: 0,
+		DB:       0,
 	})
 
 	_, err := client.Ping().Result()
@@ -44,7 +44,7 @@ func main() {
 	router := api.NewRouter(handlers)
 
 	// Run
-	if err := http.ListenAndServe(":" + appPort, router); err != nil {
+	if err := http.ListenAndServe(":"+appPort, router); err != nil {
 		log.Fatalf("Failed to run server: %v", err)
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/src/api/controllers.go
+++ b/src/api/controllers.go
@@ -1,10 +1,10 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
-    "net/http"
-	"encoding/json"
+	"net/http"
 
 	"github.com/gorilla/mux"
 
@@ -19,7 +19,7 @@ func NewGameController(svc service.GameService) *controller {
 	}
 }
 
-// GameController is interface with methods to interact with redis db	
+// GameController is interface with methods to interact with redis db
 type GameController interface {
 	NewGame(w http.ResponseWriter, r *http.Request)
 	GetGame(w http.ResponseWriter, r *http.Request)
@@ -124,9 +124,9 @@ func (c *controller) NewCard(w http.ResponseWriter, r *http.Request) {
 		ID: gameID,
 		Cards: []Card{
 			Card{
-				ID: cardID,
+				ID:    cardID,
 				Value: card.Value,
-				Used: false,
+				Used:  false,
 			},
 		},
 	}
@@ -141,7 +141,7 @@ func (c *controller) NewCard(w http.ResponseWriter, r *http.Request) {
 func (c *controller) GetGame(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	gameID := params["gameID"]
-	
+
 	gameInternal, err := c.Svc.GetGame(gameID)
 	if err != nil {
 		log.Printf("error fetching cards: %v", err)

--- a/src/api/controllers_test.go
+++ b/src/api/controllers_test.go
@@ -1,13 +1,13 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
-	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"encoding/json"
 
 	"github.com/stretchr/testify/assert"
 
@@ -15,22 +15,21 @@ import (
 	"github.com/tifmoe/go-fishbowl/src/service"
 )
 
-
 func TestNewGameController(t *testing.T) {
 
 	type test struct {
-		name 				string
-		mockService 		*mockService
-		postData 			json.RawMessage
-		expectedStatus		int
-        expectedResponse  	Response
+		name             string
+		mockService      *mockService
+		postData         json.RawMessage
+		expectedStatus   int
+		expectedResponse Response
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to create new game succeeds",
-			mockService: newMockService("successful-game"), 
-			postData: json.RawMessage(`{"team1": "boo", "team2": "hoo"}`),
+		{
+			name:           "request to create new game succeeds",
+			mockService:    newMockService("successful-game"),
+			postData:       json.RawMessage(`{"team1": "boo", "team2": "hoo"}`),
 			expectedStatus: 201,
 			expectedResponse: Response{
 				Result: []Game{
@@ -39,21 +38,21 @@ func TestNewGameController(t *testing.T) {
 					},
 				},
 				Success: true,
-				Error: []errors.Error{},
+				Error:   []errors.Error{},
 				Message: "successful-game",
 			},
 		},
 		{
-			name: "request to create new game fails on internal service layer error",
-			mockService: newMockService("error"), 
-			postData: json.RawMessage(`{"team1": "boo", "team2": "hoo"}`),
-			expectedStatus: 500, 
+			name:           "request to create new game fails on internal service layer error",
+			mockService:    newMockService("error"),
+			postData:       json.RawMessage(`{"team1": "boo", "team2": "hoo"}`),
+			expectedStatus: 500,
 			expectedResponse: Response{
-				Result: []Game{},
+				Result:  []Game{},
 				Success: false,
 				Error: []errors.Error{
 					errors.Error{
-						Code: 1000,
+						Code:    1000,
 						Message: "Failed to instantiate new game session, please try again later",
 					},
 				},
@@ -61,25 +60,25 @@ func TestNewGameController(t *testing.T) {
 			},
 		},
 		{
-			name: "request to create new game fails when team names are not provided",
-			mockService: newMockService("error"), 
-			postData: json.RawMessage(`{"invalid": "misguided input"}`),
-			expectedStatus: 500, 
+			name:           "request to create new game fails when team names are not provided",
+			mockService:    newMockService("error"),
+			postData:       json.RawMessage(`{"invalid": "misguided input"}`),
+			expectedStatus: 500,
 			expectedResponse: Response{
-				Result: []Game{},
+				Result:  []Game{},
 				Success: false,
 				Error: []errors.Error{
 					errors.Error{
-						Code: 1000,
+						Code:    1000,
 						Message: "Failed to instantiate new game session, please try again later",
 					},
 				},
 				Message: "",
 			},
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				response = Response{}
@@ -93,7 +92,6 @@ func TestNewGameController(t *testing.T) {
 			handler := http.HandlerFunc(controller.NewGame)
 			handler.ServeHTTP(rr, req)
 
-
 			if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
 				log.Fatalln(err)
 			}
@@ -101,64 +99,64 @@ func TestNewGameController(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, rr.Code)
 			assert.Equal(t, tc.expectedResponse, response)
 		})
-    }
+	}
 }
 
 func TestNewCardController(t *testing.T) {
 
 	type test struct {
-		name 				string
-		mockService 		*mockService
-		request 			func() *http.Request
-		expectedStatus		int
-        expectedResponse  	Response
+		name             string
+		mockService      *mockService
+		request          func() *http.Request
+		expectedStatus   int
+		expectedResponse Response
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to save new card succeeds",
-			mockService: newMockService("test-uuid"), 
+		{
+			name:        "request to save new card succeeds",
+			mockService: newMockService("test-uuid"),
 			request: func() *http.Request {
 				var data = []byte(`{"value":"Super funny new noun"}`)
 				req, err := http.NewRequest("POST", "/v1/api/game/test-name/card", bytes.NewBuffer(data))
 				assert.Nil(t, err)
 				return req
 			},
-			expectedStatus: 201, 
+			expectedStatus: 201,
 			expectedResponse: Response{
 				Result: []Game{
 					Game{
 						ID: "test-name",
 						Cards: []Card{
 							Card{
-								ID: "test-uuid",
+								ID:    "test-uuid",
 								Value: "Super funny new noun",
-								Used: false,
+								Used:  false,
 							},
 						},
 					},
 				},
 				Success: true,
-				Error: []errors.Error{},
+				Error:   []errors.Error{},
 				Message: "Successfully saved new card to test-name",
 			},
 		},
 		{
-			name: "request to save new card fails when POST body incorrect",
-			mockService: newMockService("test-uuid"), 
+			name:        "request to save new card fails when POST body incorrect",
+			mockService: newMockService("test-uuid"),
 			request: func() *http.Request {
 				var data = []byte(`{"not_exist":"This should fail bc invalid key"}`)
 				req, err := http.NewRequest("POST", "/v1/api/game/test-name/card", bytes.NewBuffer(data))
 				assert.Nil(t, err)
 				return req
 			},
-			expectedStatus: 400, 
+			expectedStatus: 400,
 			expectedResponse: Response{
-				Result: []Game{},
+				Result:  []Game{},
 				Success: false,
 				Error: []errors.Error{
 					errors.Error{
-						Code: 1001,
+						Code:    1001,
 						Message: "Invalid input",
 					},
 				},
@@ -166,30 +164,30 @@ func TestNewCardController(t *testing.T) {
 			},
 		},
 		{
-			name: "request to save new card fails in service or repository layer",
-			mockService: newMockService("error"), 
+			name:        "request to save new card fails in service or repository layer",
+			mockService: newMockService("error"),
 			request: func() *http.Request {
 				var data = []byte(`{"value":"Super funny new noun"}`)
 				req, err := http.NewRequest("POST", "/v1/api/game/test-name/card", bytes.NewBuffer(data))
 				assert.Nil(t, err)
 				return req
 			},
-			expectedStatus: 500, 
+			expectedStatus: 500,
 			expectedResponse: Response{
-				Result: []Game{},
+				Result:  []Game{},
 				Success: false,
 				Error: []errors.Error{
 					errors.Error{
-						Code: 5000,
+						Code:    5000,
 						Message: "Internal server error",
 					},
 				},
 				Message: "",
 			},
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				response = Response{}
@@ -207,92 +205,92 @@ func TestNewCardController(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, rr.Code)
 			assert.Equal(t, tc.expectedResponse, response)
 		})
-    }
+	}
 }
 
 func TestGetGameController(t *testing.T) {
 
 	type test struct {
-		name 				string
-		mockService 		*mockService
-		request 			func() *http.Request
-		expectedStatus		int
-        expectedResponse  	Response
+		name             string
+		mockService      *mockService
+		request          func() *http.Request
+		expectedStatus   int
+		expectedResponse Response
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to fetch cards for game with one card succeeds",
-			mockService: newMockService("single"), 
+		{
+			name:        "request to fetch cards for game with one card succeeds",
+			mockService: newMockService("single"),
 			request: func() *http.Request {
 				req, err := http.NewRequest("GET", "/v1/api/game/single", nil)
 				assert.Nil(t, err)
 				return req
 			},
-			expectedStatus: 200, 
+			expectedStatus: 200,
 			expectedResponse: Response{
 				Result: []Game{
 					Game{
 						ID: "single",
 						Cards: []Card{
 							Card{
-								ID: "test-card",
+								ID:    "test-card",
 								Value: "Pants king",
-								Used: false,
+								Used:  false,
 							},
 						},
 					},
 				},
 				Success: true,
-				Error: []errors.Error{},
+				Error:   []errors.Error{},
 				Message: "Game single has 1 cards",
 			},
 		},
 		{
-			name: "request to fetch cards for game with no cards succeeds",
-			mockService: newMockService("empty"), 
+			name:        "request to fetch cards for game with no cards succeeds",
+			mockService: newMockService("empty"),
 			request: func() *http.Request {
 				req, err := http.NewRequest("GET", "/v1/api/game/empty", nil)
 				assert.Nil(t, err)
 				return req
 			},
-			expectedStatus: 200, 
+			expectedStatus: 200,
 			expectedResponse: Response{
 				Result: []Game{
 					Game{
-						ID: "empty",
+						ID:    "empty",
 						Cards: []Card{},
 					},
 				},
 				Success: true,
-				Error: []errors.Error{},
+				Error:   []errors.Error{},
 				Message: "Game empty has 0 cards",
 			},
 		},
 		{
-			name: "request to fetch cards fails when internal error",
-			mockService: newMockService("error"), 
+			name:        "request to fetch cards fails when internal error",
+			mockService: newMockService("error"),
 			request: func() *http.Request {
 				req, err := http.NewRequest("GET", "/v1/api/game/error", nil)
 				assert.Nil(t, err)
 				return req
 			},
-			expectedStatus: 500, 
+			expectedStatus: 500,
 			expectedResponse: Response{
-				Result: []Game{},
+				Result:  []Game{},
 				Success: false,
 				Error: []errors.Error{
 					errors.Error{
-						Code: 5000,
+						Code:    5000,
 						Message: "Internal server error",
 					},
 				},
 				Message: "",
 			},
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				response = Response{}
@@ -310,23 +308,22 @@ func TestGetGameController(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, rr.Code)
 			assert.Equal(t, tc.expectedResponse, response)
 		})
-    }
+	}
 }
-
 
 func TestGetRandomCardController(t *testing.T) {
 
 	type test struct {
-		name 				string
-		mockService 		*mockService
-		expectedStatus		int
-        expectedResponse  	Response
+		name             string
+		mockService      *mockService
+		expectedStatus   int
+		expectedResponse Response
 	}
 
 	tests := []test{
-        {
-			name: "request to fetch random card for game succeeds",
-			mockService: newMockService("single"),
+		{
+			name:           "request to fetch random card for game succeeds",
+			mockService:    newMockService("single"),
 			expectedStatus: 200,
 			expectedResponse: Response{
 				Result: []Game{
@@ -334,53 +331,53 @@ func TestGetRandomCardController(t *testing.T) {
 						ID: "single",
 						Cards: []Card{
 							Card{
-								ID: "random-card",
+								ID:    "random-card",
 								Value: "Trump's carrot fingers",
-								Used: false,
+								Used:  false,
 							},
 						},
 					},
 				},
 				Success: true,
-				Error: []errors.Error{},
+				Error:   []errors.Error{},
 				Message: "",
 			},
 		},
 		{
-			name: "request to fetch random card when no unused cards left is successful",
-			mockService: newMockService("empty"),
+			name:           "request to fetch random card when no unused cards left is successful",
+			mockService:    newMockService("empty"),
 			expectedStatus: 200,
 			expectedResponse: Response{
 				Result: []Game{
 					Game{
-						ID: "empty",
+						ID:    "empty",
 						Cards: []Card{},
 					},
 				},
 				Success: true,
-				Error: []errors.Error{},
+				Error:   []errors.Error{},
 				Message: "",
 			},
 		},
 		{
-			name: "request to fetch random card fails when internal error",
-			mockService: newMockService("error"),
+			name:           "request to fetch random card fails when internal error",
+			mockService:    newMockService("error"),
 			expectedStatus: 500,
 			expectedResponse: Response{
-				Result: []Game{},
+				Result:  []Game{},
 				Success: false,
 				Error: []errors.Error{
 					errors.Error{
-						Code: 5000,
+						Code:    5000,
 						Message: "Internal server error",
 					},
 				},
 				Message: "",
 			},
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				response = Response{}
@@ -390,7 +387,7 @@ func TestGetRandomCardController(t *testing.T) {
 			controller := NewGameController(tc.mockService)
 			router := NewRouter(controller)
 
-			req, err := http.NewRequest("GET",  "/v1/api/game/game-name/card/random", nil)
+			req, err := http.NewRequest("GET", "/v1/api/game/game-name/card/random", nil)
 			assert.Nil(t, err)
 			router.ServeHTTP(rr, req)
 			if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
@@ -400,7 +397,7 @@ func TestGetRandomCardController(t *testing.T) {
 			assert.Equal(t, tc.expectedStatus, rr.Code)
 			assert.Equal(t, tc.expectedResponse, response)
 		})
-    }
+	}
 }
 
 func newMockService(c string) *mockService {
@@ -431,7 +428,7 @@ func (s *mockService) SaveCard(gameID string, card *service.CardInput) (string, 
 	}
 }
 
-func (s *mockService) GetGame(gameID string) (*service.Game, error){
+func (s *mockService) GetGame(gameID string) (*service.Game, error) {
 	game := &service.Game{}
 
 	switch s.Case {
@@ -441,9 +438,9 @@ func (s *mockService) GetGame(gameID string) (*service.Game, error){
 		game.ID = "single"
 		game.Cards = []service.Card{
 			service.Card{
-				ID: "test-card",
+				ID:    "test-card",
 				Value: "Pants king",
-				Used: false,
+				Used:  false,
 			},
 		}
 		return game, nil
@@ -456,7 +453,6 @@ func (s *mockService) GetGame(gameID string) (*service.Game, error){
 	}
 }
 
-
 func (s *mockService) GetRandomCard(gameID string) (card *service.Card, err error) {
 	switch s.Case {
 	case "error":
@@ -464,10 +460,10 @@ func (s *mockService) GetRandomCard(gameID string) (card *service.Card, err erro
 		return
 	case "single":
 		card = &service.Card{
-				ID: "random-card",
-				Value: "Trump's carrot fingers",
-				Used: false,
-			}
+			ID:    "random-card",
+			Value: "Trump's carrot fingers",
+			Used:  false,
+		}
 		return
 	}
 	return
@@ -489,4 +485,3 @@ func (s *mockService) UpdateGame(gameID string, input *service.GameInput) (*serv
 	var game *service.Game
 	return game, nil
 }
-

--- a/src/api/models.go
+++ b/src/api/models.go
@@ -7,49 +7,49 @@ import (
 
 // apiResponse contains status code and json response to be served by API
 type apiResponse struct {
-	Status 	int 
-	Data 	*Response
+	Status int
+	Data   *Response
 }
 
 // Response contains json response
 type Response struct {
-	Result 		[]Game 			`json:"result"`
-	Success		bool 			`json:"success"`
-	Error 		[]errors.Error 	`json:"error"`
-	Message		string 			`json:"message"`
+	Result  []Game         `json:"result"`
+	Success bool           `json:"success"`
+	Error   []errors.Error `json:"error"`
+	Message string         `json:"message"`
 }
 
 // Game contains data a specific game session
 type Game struct {
-	ID     			string 	`json:"id"`
-	Cards   		[]Card	`json:"cards"`
-	Started			bool 	`json:"started"`
-	CurrentRound	int		`json:"current_round"`
-	Team1Turn		bool	`json:"team_1_turn"`
-	UnusedCards		int		`json:"unused_cards"`
-	Teams			Teams 	`json:"teams"`
+	ID           string `json:"id"`
+	Cards        []Card `json:"cards"`
+	Started      bool   `json:"started"`
+	CurrentRound int    `json:"current_round"`
+	Team1Turn    bool   `json:"team_1_turn"`
+	UnusedCards  int    `json:"unused_cards"`
+	Teams        Teams  `json:"teams"`
 }
 
 // Card contains data for a specific card
 type Card struct {
-	ID 		string	`json:"id"`
-	Value   string  `json:"value"`
-	Used 	bool  	`json:"used"`
+	ID    string `json:"id"`
+	Value string `json:"value"`
+	Used  bool   `json:"used"`
 }
 
 // Teams is nested struct containing details for each of the two teams
 type Teams struct {
-	Team1 	Team `json:"team_1"`
-	Team2 	Team `json:"team_2"`
+	Team1 Team `json:"team_1"`
+	Team2 Team `json:"team_2"`
 }
 
 // Team contains data for a specific
 type Team struct {
-	Name		string	`json:"name"`
-	Round1		int		`json:"round_1_pts"`
-	Round2   	int		`json:"round_2_pts"`
-	Round3   	int		`json:"round_3_pts"`
-	Round4   	int		`json:"round_4_pts"`
+	Name   string `json:"name"`
+	Round1 int    `json:"round_1_pts"`
+	Round2 int    `json:"round_2_pts"`
+	Round3 int    `json:"round_3_pts"`
+	Round4 int    `json:"round_4_pts"`
 }
 
 // TODO: This is gross, optimize later

--- a/src/api/router.go
+++ b/src/api/router.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	staticPath = "./web"
-	indexPath = "index.html"
+	indexPath  = "index.html"
 )
 
 // NewRouter will build a new router for the routes defined below
@@ -29,7 +29,7 @@ func NewRouter(c GameController) *mux.Router {
 	// Card resource
 	api.HandleFunc("/game/{gameID}/card", c.NewCard).Methods("POST")
 	api.HandleFunc("/game/{gameID}/card/{cardID}/used", c.MarkCardUsed).Methods("PATCH") // marks single card as used
-	api.HandleFunc("/game/{gameID}/card/random", c.GetRandomCard).Methods("GET") // returns a random un-used card
+	api.HandleFunc("/game/{gameID}/card/random", c.GetRandomCard).Methods("GET")         // returns a random un-used card
 
 	// Serve Frontend routes
 	// For requests to dynamically generated game pages, serve index.html

--- a/src/api/util.go
+++ b/src/api/util.go
@@ -1,11 +1,11 @@
 package api
 
 import (
-	"os"
+	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
-	"encoding/json"
 
 	"github.com/tifmoe/go-fishbowl/src/errors"
 )
@@ -54,7 +54,7 @@ func buildResponse(game Game, er *errors.ErrorInternal, message string) *apiResp
 
 	return &apiResponse{
 		Status: status,
-		Data: res,
+		Data:   res,
 	}
 }
 
@@ -65,18 +65,18 @@ func buildResult(g Game, m string) *Response {
 	}
 
 	return &Response{
-		Result: game,
+		Result:  game,
 		Success: true,
-		Error: []errors.Error{},
+		Error:   []errors.Error{},
 		Message: m,
 	}
 }
 
 func buildError(e *errors.Error) *Response {
 	return &Response{
-		Result: []Game{},
+		Result:  []Game{},
 		Success: false,
-		Error: []errors.Error{*e},
+		Error:   []errors.Error{*e},
 		Message: "",
 	}
 }

--- a/src/errors/errors.go
+++ b/src/errors/errors.go
@@ -7,19 +7,19 @@ import (
 var (
 	// ErrNewGame is thrown when service fails to instantiate a new game
 	ErrNewGame = &ErrorInternal{
-		Status: http.StatusInternalServerError, 
-		Error: &Error{Code: 1000, Message: "Failed to instantiate new game session, please try again later"},
+		Status: http.StatusInternalServerError,
+		Error:  &Error{Code: 1000, Message: "Failed to instantiate new game session, please try again later"},
 	}
 
 	// ErrInvalidInput is thrown when input is invalid
 	ErrInvalidInput = &ErrorInternal{
-		Status: http.StatusBadRequest, 
-		Error: &Error{Code: 1001, Message: "Invalid input"},
+		Status: http.StatusBadRequest,
+		Error:  &Error{Code: 1001, Message: "Invalid input"},
 	}
 
 	// ErrInternalError is thrown when an unknown error in the service or repository layer is thrown
 	ErrInternalError = &ErrorInternal{
-		Status: http.StatusInternalServerError, 
-		Error: &Error{Code: 5000, Message: "Internal server error"},
+		Status: http.StatusInternalServerError,
+		Error:  &Error{Code: 5000, Message: "Internal server error"},
 	}
 )

--- a/src/errors/models.go
+++ b/src/errors/models.go
@@ -2,22 +2,22 @@ package errors
 
 // ErrorInternal contains internal definition of an error
 type ErrorInternal struct {
-	Status 	int		`json:"status,omitempty"`
-	Error 	*Error	`json:"error,omitempty"`
+	Status int    `json:"status,omitempty"`
+	Error  *Error `json:"error,omitempty"`
 }
 
 // IsEmpty will return true if Error struct does not contain something other than default
 func (e ErrorInternal) IsEmpty() bool {
-    return e.Status == 0
+	return e.Status == 0
 }
 
 // Error holds info on the error response
 type Error struct {
-	Code 	int 	`json:"code"`
+	Code    int    `json:"code"`
 	Message string `json:"message"`
 }
 
 // IsEmpty will return true if Error struct does not contain something other than default
 func (e Error) IsEmpty() bool {
-    return e.Message == ""
+	return e.Message == ""
 }

--- a/src/repository/models.go
+++ b/src/repository/models.go
@@ -4,40 +4,40 @@ import "log"
 
 // Game is the DTO for a specific game
 type Game struct {
-	ID     string 		`json:"id,omitempty"`
-	Cards   []Card		`json:"cards,omitempty"`
-	Started		bool 	`json:"started"`
-	Round		int		`json:"current_round"`
-	Team1Turn	bool	`json:"team_1_turn"`
-	Teams		Teams	`json:"teams"`
+	ID        string `json:"id,omitempty"`
+	Cards     []Card `json:"cards,omitempty"`
+	Started   bool   `json:"started"`
+	Round     int    `json:"current_round"`
+	Team1Turn bool   `json:"team_1_turn"`
+	Teams     Teams  `json:"teams"`
 }
 
 // Card is the DTO for card values
 type Card struct {
-	ID 		string		`json:"id,omitempty"`
-	Value   string     `json:"value,omitempty"`
-	Used 	bool       `json:"used"`
+	ID    string `json:"id,omitempty"`
+	Value string `json:"value,omitempty"`
+	Used  bool   `json:"used"`
 }
 
 // Teams is nested struct containing details for each of the two teams
 type Teams struct {
-	Team1 	Team `json:"team_1"`
-	Team2 	Team `json:"team_2"`
+	Team1 Team `json:"team_1"`
+	Team2 Team `json:"team_2"`
 }
 
 // Team contains data for a specific
 type Team struct {
-	Name		string		`json:"name"`
-	Round1   	[]string	`json:"round_1"`
-	Round2   	[]string	`json:"round_2"`
-	Round3   	[]string	`json:"round_3"`
-	Round4   	[]string	`json:"round_4"`
+	Name   string   `json:"name"`
+	Round1 []string `json:"round_1"`
+	Round2 []string `json:"round_2"`
+	Round3 []string `json:"round_3"`
+	Round4 []string `json:"round_4"`
 }
 
 // AddCard is helper function to add a new gard to an existing game
 func (game *Game) AddCard(c Card) []Card {
-    game.Cards = append(game.Cards, c)
-    return game.Cards
+	game.Cards = append(game.Cards, c)
+	return game.Cards
 }
 
 // IncrementPoints is helper function to increment the number of points a team has won in a given round

--- a/src/repository/store.go
+++ b/src/repository/store.go
@@ -19,16 +19,16 @@ func NewRedisConnection(c *redis.Client) *conn {
 	}
 }
 
-// Repository is interface with methods to interact with redis db	
+// Repository is interface with methods to interact with redis db
 type Repository interface {
-    SaveNewGame(gameID, team1, team2 string) error
+	SaveNewGame(gameID, team1, team2 string) error
 	UpdateGame(game *Game) error
 	GetGame(gameID string) (game *Game, err error)
 }
 
 // conn is a struct holding the redis client
 type conn struct {
-    Client *redis.Client
+	Client *redis.Client
 }
 
 // SaveNewGame is used to initialize a new game
@@ -56,23 +56,23 @@ func (c conn) SaveNewGame(gameID, team1, team2 string) error {
 		fmt.Printf("Error marshalling new game %s: %v\n", gameID, err)
 		return err
 	}
-    err = c.Client.Set(gameID, game, ttl).Err()
-    if err != nil {
+	err = c.Client.Set(gameID, game, ttl).Err()
+	if err != nil {
 		fmt.Printf("Error saving game %s: %v\n", gameID, err)
-        return err
+		return err
 	}
 	return nil
 }
 
 func (c conn) GetGame(gameID string) (game *Game, err error) {
-    data, err := c.Client.Get(gameID).Result()
-    if err != nil {
+	data, err := c.Client.Get(gameID).Result()
+	if err != nil {
 		fmt.Printf("Game %s does not exist: %v\n", gameID, err)
 		return game, err
-    }
+	}
 
 	err = json.Unmarshal([]byte(data), &game)
-    if err != nil {
+	if err != nil {
 		fmt.Printf("Error marshalling game %s: %v\n", gameID, err)
 		return game, err
 	}
@@ -82,15 +82,15 @@ func (c conn) GetGame(gameID string) (game *Game, err error) {
 func (c conn) UpdateGame(game *Game) error {
 	gameID := game.ID
 	updatedGame, err := json.Marshal(game)
-    if err != nil {
+	if err != nil {
 		fmt.Printf("Error marshalling updated game %s: %v\n", gameID, err)
 		return err
 	}
 
-    err = c.Client.Set(gameID, updatedGame, ttl).Err()
-    if err != nil {
+	err = c.Client.Set(gameID, updatedGame, ttl).Err()
+	if err != nil {
 		fmt.Printf("Error saving game %v: %v\n", gameID, err)
 		return err
-    }
+	}
 	return nil
 }

--- a/src/service/game_test.go
+++ b/src/service/game_test.go
@@ -9,42 +9,41 @@ import (
 	"github.com/tifmoe/go-fishbowl/src/repository"
 )
 
-
 func TestNewGameService(t *testing.T) {
 
 	type test struct {
-		name 				string
-		mockRepo 			*mockRepo
-		mockRand			*mockRand
-		expectedResponse  	string
-		expectedError		error
+		name             string
+		mockRepo         *mockRepo
+		mockRand         *mockRand
+		expectedResponse string
+		expectedError    error
 	}
-	
-	tests := []test{
-        {
-			name: "request to create new game succeeds",
-			mockRepo: newMockRepo("hungry-hippo"), 
-			mockRand: newMockRand("hungry-hippo"),
-			expectedResponse: "hungry-hippo",
-			expectedError: nil,
-		},
-		{
-			name: "request to create new game fails on randomizer error",
-			mockRepo: newMockRepo("hungry-hippo"), 
-			mockRand: newMockRand("error"),
-			expectedResponse: "",
-			expectedError: fmt.Errorf("failed to generate random name"),
-		},
-		{
-			name: "request to create new game fails on repository error",
-			mockRepo: newMockRepo("error"), 
-			mockRand: newMockRand("hungry-hippo"),
-			expectedResponse: "",
-			expectedError: fmt.Errorf("failed to save new game hungry-hippo"),
-		},
-    }
 
-    for _, tc := range tests {
+	tests := []test{
+		{
+			name:             "request to create new game succeeds",
+			mockRepo:         newMockRepo("hungry-hippo"),
+			mockRand:         newMockRand("hungry-hippo"),
+			expectedResponse: "hungry-hippo",
+			expectedError:    nil,
+		},
+		{
+			name:             "request to create new game fails on randomizer error",
+			mockRepo:         newMockRepo("hungry-hippo"),
+			mockRand:         newMockRand("error"),
+			expectedResponse: "",
+			expectedError:    fmt.Errorf("failed to generate random name"),
+		},
+		{
+			name:             "request to create new game fails on repository error",
+			mockRepo:         newMockRepo("error"),
+			mockRand:         newMockRand("hungry-hippo"),
+			expectedResponse: "",
+			expectedError:    fmt.Errorf("failed to save new game hungry-hippo"),
+		},
+	}
+
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			svc := NewGameService(tc.mockRepo, tc.mockRand, 3)
 
@@ -54,74 +53,74 @@ func TestNewGameService(t *testing.T) {
 			assert.Equal(t, tc.expectedResponse, gameID)
 			assert.Equal(t, tc.expectedError, err)
 		})
-    }
+	}
 }
 
 func TestSaveCardService(t *testing.T) {
 
 	type test struct {
-		name 				string
-		newCard				*CardInput
-		gameID				string
-		maxCards			int
-		expectedError		error
+		name          string
+		newCard       *CardInput
+		gameID        string
+		maxCards      int
+		expectedError error
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to save new card succeeds",
-			newCard: &CardInput{Value: "new-value"},
-			gameID: "two-cards",
-			maxCards: 30,
+		{
+			name:          "request to save new card succeeds",
+			newCard:       &CardInput{Value: "new-value"},
+			gameID:        "two-cards",
+			maxCards:      30,
 			expectedError: nil,
 		},
 		{
-			name: "request to save new card fails if max cards already exist",
-			newCard: &CardInput{Value: "new-value"},
-			gameID: "two-cards",
-			maxCards: 2,
+			name:          "request to save new card fails if max cards already exist",
+			newCard:       &CardInput{Value: "new-value"},
+			gameID:        "two-cards",
+			maxCards:      2,
 			expectedError: fmt.Errorf("game already has maximum number of cards"),
 		},
 		{
-			name: "request to save new card fails if game does not exist",
-			newCard: &CardInput{Value: "new-value"},
-			gameID: "error",
-			maxCards: 10,
+			name:          "request to save new card fails if game does not exist",
+			newCard:       &CardInput{Value: "new-value"},
+			gameID:        "error",
+			maxCards:      10,
 			expectedError: fmt.Errorf("game error does not exist"),
 		},
 		{
-			name: "request to save new card fails if value not provided",
-			newCard: &CardInput{},
-			gameID: "two-cards",
-			maxCards: 10,
+			name:          "request to save new card fails if value not provided",
+			newCard:       &CardInput{},
+			gameID:        "two-cards",
+			maxCards:      10,
 			expectedError: fmt.Errorf("invalid card input"),
 		},
 		{
-			name: "request to save new card fails if value exceeds max char number",
-			newCard: &CardInput{Value: "exceedingly verbose individual enters in a card value which is far too long"},
-			gameID: "two-cards",
-			maxCards: 10,
+			name:          "request to save new card fails if value exceeds max char number",
+			newCard:       &CardInput{Value: "exceedingly verbose individual enters in a card value which is far too long"},
+			gameID:        "two-cards",
+			maxCards:      10,
 			expectedError: fmt.Errorf("invalid card input"),
 		},
 		{
-			name: "request to save new card fails if value exceeds max char number",
-			newCard: &CardInput{Value: "exceedingly verbose individual enters in a card value which is far too long"},
-			gameID: "two-cards",
-			maxCards: 10,
+			name:          "request to save new card fails if value exceeds max char number",
+			newCard:       &CardInput{Value: "exceedingly verbose individual enters in a card value which is far too long"},
+			gameID:        "two-cards",
+			maxCards:      10,
 			expectedError: fmt.Errorf("invalid card input"),
 		},
 		{
-			name: "request to save new card fails if game could not be updated",
-			newCard: &CardInput{Value: "valid-input"},
-			gameID: "update-error",
-			maxCards: 10,
+			name:          "request to save new card fails if game could not be updated",
+			newCard:       &CardInput{Value: "valid-input"},
+			gameID:        "update-error",
+			maxCards:      10,
 			expectedError: fmt.Errorf("error updateing game with new card"),
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRepo := newMockRepo(tc.gameID) 
+			mockRepo := newMockRepo(tc.gameID)
 			mockRand := newMockRand(tc.gameID)
 			svc := NewGameService(mockRepo, mockRand, tc.maxCards)
 
@@ -129,34 +128,34 @@ func TestSaveCardService(t *testing.T) {
 			assert.NotNil(t, cardID)
 			assert.Equal(t, tc.expectedError, err)
 		})
-    }
+	}
 }
 
 func TestGetGameService(t *testing.T) {
 
 	type test struct {
-		name 				string
-		gameID				string
-		expectGame			*Game
-		expectedError		error
+		name          string
+		gameID        string
+		expectGame    *Game
+		expectedError error
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to get existing game succeeds",
+		{
+			name:   "request to get existing game succeeds",
 			gameID: "two-cards",
 			expectGame: &Game{
 				ID: "hungry-hippos",
 				Cards: []Card{
 					Card{
-						ID: "card-1",
+						ID:    "card-1",
 						Value: "value-1",
-						Used: false,
+						Used:  false,
 					},
 					Card{
-						ID: "card-2",
+						ID:    "card-2",
 						Value: "value-2",
-						Used: false,
+						Used:  false,
 					},
 				},
 				UnusedCards: 2,
@@ -164,16 +163,16 @@ func TestGetGameService(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "request to get game fails when repo returns an error",
-			gameID: "error",
-			expectGame: nil,
+			name:          "request to get game fails when repo returns an error",
+			gameID:        "error",
+			expectGame:    nil,
 			expectedError: fmt.Errorf("failed to fetch game"),
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRepo := newMockRepo(tc.gameID) 
+			mockRepo := newMockRepo(tc.gameID)
 			mockRand := newMockRand(tc.gameID)
 			svc := NewGameService(mockRepo, mockRand, 10)
 
@@ -181,43 +180,43 @@ func TestGetGameService(t *testing.T) {
 			assert.Equal(t, tc.expectGame, game)
 			assert.Equal(t, tc.expectedError, err)
 		})
-    }
+	}
 }
 
 func TestGetRandomCardService(t *testing.T) {
 
 	type test struct {
-		name 				string
-		gameID				string
-		mockRandCase		string
-		expectCard			*Card
-		expectedError		error
+		name          string
+		gameID        string
+		mockRandCase  string
+		expectCard    *Card
+		expectedError error
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to get random card succeeds",
-			gameID: "two-cards",
-			mockRandCase: "first", 
+		{
+			name:         "request to get random card succeeds",
+			gameID:       "two-cards",
+			mockRandCase: "first",
 			expectCard: &Card{
-				ID: "card-1",
+				ID:    "card-1",
 				Value: "value-1",
-				Used: false,
+				Used:  false,
 			},
 			expectedError: nil,
 		},
 		{
-			name: "request to get random card returns nil when all cards used",
-			gameID: "all-cards-used",
-			mockRandCase: "first", 
-			expectCard: nil,
+			name:          "request to get random card returns nil when all cards used",
+			gameID:        "all-cards-used",
+			mockRandCase:  "first",
+			expectCard:    nil,
 			expectedError: nil,
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRepo := newMockRepo(tc.gameID) 
+			mockRepo := newMockRepo(tc.gameID)
 			mockRand := newMockRand(tc.mockRandCase)
 			svc := NewGameService(mockRepo, mockRand, 10)
 
@@ -225,85 +224,85 @@ func TestGetRandomCardService(t *testing.T) {
 			assert.Equal(t, tc.expectCard, card)
 			assert.Equal(t, tc.expectedError, err)
 		})
-    }
+	}
 }
 
 func TestMarkCardUsedService(t *testing.T) {
 
 	type test struct {
-		name 				string
-		gameID				string
-		cardID				string
-		expectedError		error
+		name          string
+		gameID        string
+		cardID        string
+		expectedError error
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to mark card as used succeeds",
-			gameID: "two-cards",
-			cardID: "card-1",
+		{
+			name:          "request to mark card as used succeeds",
+			gameID:        "two-cards",
+			cardID:        "card-1",
 			expectedError: nil,
 		},
 		{
-			name: "request to mark card as used fails when card not found in game",
-			gameID: "two-cards",
-			cardID: "card-not-exists",
+			name:          "request to mark card as used fails when card not found in game",
+			gameID:        "two-cards",
+			cardID:        "card-not-exists",
 			expectedError: fmt.Errorf("card card-not-exists not found in game two-cards"),
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRepo := newMockRepo(tc.gameID) 
+			mockRepo := newMockRepo(tc.gameID)
 			mockRand := newMockRand(tc.gameID)
 			svc := NewGameService(mockRepo, mockRand, 10)
 
 			_, err := svc.MarkCardUsed(tc.gameID, tc.cardID)
 			assert.Equal(t, tc.expectedError, err)
 		})
-    }
+	}
 }
 
 func TestResetGameService(t *testing.T) {
 
 	type test struct {
-		name 				string
-		gameID				string
-		expectGame			*Game
-		expectedError		error
+		name          string
+		gameID        string
+		expectGame    *Game
+		expectedError error
 	}
-	
+
 	tests := []test{
-        {
-			name: "request to set cards as unused succeeds",
+		{
+			name:   "request to set cards as unused succeeds",
 			gameID: "all-cards-used",
 			expectGame: &Game{
 				ID: "hungry-hippos",
 				Cards: []Card{
 					Card{
-						ID: "card-1",
+						ID:    "card-1",
 						Value: "value-1",
-						Used: false,
+						Used:  false,
 					},
 				},
-				Started: true,
-				Round: 1,
-				Team1Turn: true,
+				Started:     true,
+				Round:       1,
+				Team1Turn:   true,
 				UnusedCards: 1,
 			},
 			expectedError: nil,
 		},
 		{
-			name: "request to set cards as unused fails when repository error getting game",
-			gameID: "error",
-			expectGame: nil,
+			name:          "request to set cards as unused fails when repository error getting game",
+			gameID:        "error",
+			expectGame:    nil,
 			expectedError: fmt.Errorf("Game does not exist"),
 		},
-    }
+	}
 
-    for _, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRepo := newMockRepo(tc.gameID) 
+			mockRepo := newMockRepo(tc.gameID)
 			mockRand := newMockRand(tc.gameID)
 			svc := NewGameService(mockRepo, mockRand, 10)
 
@@ -311,9 +310,8 @@ func TestResetGameService(t *testing.T) {
 			assert.Equal(t, tc.expectGame, game)
 			assert.Equal(t, tc.expectedError, err)
 		})
-    }
+	}
 }
-
 
 // Mock Repository Interface
 func newMockRepo(c string) *mockRepo {
@@ -353,14 +351,14 @@ func (s *mockRepo) GetGame(gameID string) (game *repository.Game, err error) {
 			ID: "hungry-hippos",
 			Cards: []repository.Card{
 				repository.Card{
-					ID: "card-1",
+					ID:    "card-1",
 					Value: "value-1",
-					Used: false,
+					Used:  false,
 				},
 				repository.Card{
-					ID: "card-2",
+					ID:    "card-2",
 					Value: "value-2",
-					Used: false,
+					Used:  false,
 				},
 			},
 		}, nil
@@ -369,9 +367,9 @@ func (s *mockRepo) GetGame(gameID string) (game *repository.Game, err error) {
 			ID: "hungry-hippos",
 			Cards: []repository.Card{
 				repository.Card{
-					ID: "card-1",
+					ID:    "card-1",
 					Value: "value-1",
-					Used: true,
+					Used:  true,
 				},
 			},
 		}, nil
@@ -404,9 +402,9 @@ func (s *mockRand) GetRandomCard(cards []Card) *Card {
 	switch s.Value {
 	case "first":
 		return &Card{
-			ID: "card-1",
+			ID:    "card-1",
 			Value: "value-1",
-			Used: false,
+			Used:  false,
 		}
 	default:
 		return &Card{}

--- a/src/service/models.go
+++ b/src/service/models.go
@@ -6,70 +6,69 @@ import (
 
 // WordChoices is struct to hold selection of random words to choose from
 type WordChoices struct {
-	Nouns 	   []string 	`json:"nouns"`
-	Adjectives []string 	`json:"adjectives"`
+	Nouns      []string `json:"nouns"`
+	Adjectives []string `json:"adjectives"`
 }
 
 // CardInput contains value for new card from game
 type CardInput struct {
-	Value		string `json:"value" validate:"required,min=2,max=30"`
+	Value string `json:"value" validate:"required,min=2,max=30"`
 }
 
 // IsEmpty will return true if Error struct does not contain something other than default
 func (c CardInput) IsEmpty() bool {
-    return c.Value == ""
+	return c.Value == ""
 }
 
 // GameInput contains value for updates to game data
 type GameInput struct {
-	Started			*bool 	`json:"started,omitempty"`
-	Round			*int	`json:"current_round,omitempty" validate:"max=5"`
-	Team1Turn		*bool	`json:"team_1_turn,omitempty"`
-
+	Started   *bool `json:"started,omitempty"`
+	Round     *int  `json:"current_round,omitempty" validate:"max=5"`
+	Team1Turn *bool `json:"team_1_turn,omitempty"`
 }
 
 // TeamInput contains value for team names
 type TeamInput struct {
-	Team1			*string	`json:"team_1,omitempty" validate:"required,min=2,max=30"`
-	Team2			*string	`json:"team_2,omitempty" validate:"required,min=2,max=30"`
+	Team1 *string `json:"team_1,omitempty" validate:"required,min=2,max=30"`
+	Team2 *string `json:"team_2,omitempty" validate:"required,min=2,max=30"`
 }
 
 // IsEmpty will return true if Error struct does not contain something other than default
 func (t TeamInput) IsEmpty() bool {
-    return &t.Team1 == nil || &t.Team2 == nil
+	return &t.Team1 == nil || &t.Team2 == nil
 }
 
 // Game is the internal struct for a game object
 type Game struct {
-	ID     string 		`json:"id,omitempty"`
-	Cards   []Card		`json:"cards,omitempty"`
-	Started		bool 	`json:"started,omitempty"`
-	Round		int		`json:"current_round,omitempty"`
-	Team1Turn	bool	`json:"team_1_turn,omitempty"`
-	UnusedCards	int		`json:"unused_cards,omitempty"`
-	Teams		Teams 	`json:"teams,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Cards       []Card `json:"cards,omitempty"`
+	Started     bool   `json:"started,omitempty"`
+	Round       int    `json:"current_round,omitempty"`
+	Team1Turn   bool   `json:"team_1_turn,omitempty"`
+	UnusedCards int    `json:"unused_cards,omitempty"`
+	Teams       Teams  `json:"teams,omitempty"`
 }
 
 // Card is the internal struct for a card object
 type Card struct {
-	ID 		string	`json:"id,omitempty"`
-	Value   string  `json:"value,omitempty"`
-	Used 	bool    `json:"used,omitempty"`
+	ID    string `json:"id,omitempty"`
+	Value string `json:"value,omitempty"`
+	Used  bool   `json:"used,omitempty"`
 }
 
 // Teams is nested struct containing details for each of the two teams
 type Teams struct {
-	Team1 	Team `json:"team_1,omitempty"`
-	Team2 	Team `json:"team_2,omitempty"`
+	Team1 Team `json:"team_1,omitempty"`
+	Team2 Team `json:"team_2,omitempty"`
 }
 
 // Team contains data for a specific
 type Team struct {
-	Name		string		`json:"name,omitempty"`
-	Round1   	[]string	`json:"round_1,omitempty"`
-	Round2   	[]string	`json:"round_2,omitempty"`
-	Round3   	[]string	`json:"round_3,omitempty"`
-	Round4   	[]string	`json:"round_4,omitempty"`
+	Name   string   `json:"name,omitempty"`
+	Round1 []string `json:"round_1,omitempty"`
+	Round2 []string `json:"round_2,omitempty"`
+	Round3 []string `json:"round_3,omitempty"`
+	Round4 []string `json:"round_4,omitempty"`
 }
 
 // TODO: This is gross, optimize later
@@ -104,7 +103,6 @@ func gameDTOtoInternal(dto *repository.Game) *Game {
 
 	return game
 }
-
 
 func dtoToInternalTeam(dto repository.Team) Team {
 	t := Team{}

--- a/src/service/random.go
+++ b/src/service/random.go
@@ -1,11 +1,11 @@
 package service
 
 import (
-    "encoding/json"
-    "fmt"
-	"io/ioutil"	
-	"path/filepath"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"math/rand"
+	"path/filepath"
 	"time"
 )
 
@@ -16,11 +16,11 @@ func NewRandomService() RandomService {
 
 // RandomService is interface for collection of methods to draw random values
 type RandomService interface {
-    GetRandomCard(cards []Card) *Card
+	GetRandomCard(cards []Card) *Card
 	GetRandomWords() (string, error)
 }
 
-type random struct {}
+type random struct{}
 
 // GetRandomCard is utility function to select a random card from a slice
 func (r *random) GetRandomCard(cards []Card) *Card {
@@ -49,13 +49,13 @@ func randPicker(words []string) string {
 func readWords() (words *WordChoices, err error) {
 	// TODO store words in noSQL db when we create it
 	// read file from assets for now
-	absPath, _ := filepath.Abs("./assets/randwords.json")  // path from the working directory
+	absPath, _ := filepath.Abs("./assets/randwords.json") // path from the working directory
 	data, err := ioutil.ReadFile(absPath)
 	if err != nil {
 		fmt.Println("error:", err)
 		return
 	}
-	
+
 	// unmarshall data into word choices struct
 	err = json.Unmarshal(data, &words)
 	if err != nil {


### PR DESCRIPTION
There was probably a faster way of doing this, but I went through all the go files and saved them with "editor.formatOnSave: true" in my go settings (Maybe there was a command to do them all at once but it took like 30 seconds to save all the files). 

I think that all changes after this should be formatted in the same way. This way, subsequent commits don't have stray changes due to the formatter. 

To use gofmt, open up the settings and navigate here:

![image](https://user-images.githubusercontent.com/9022917/82589793-e6839880-9b59-11ea-8669-002f703b93c7.png)
