### PR TITLE
Make sure only /ws requests are handled by the websocket router

### DIFF
--- a/cmd/go-fishbowl/main.go
+++ b/cmd/go-fishbowl/main.go
@@ -50,12 +50,12 @@ func main() {
 	handlers := api.NewGameController(svc)
 	pool := api.NewPool()
 	go pool.Start()
+	wsRouter := api.NewRouter(pool, handlers)
 
-	router := api.NewRouter(pool, handlers)
-	http.Handle("/v1/api/", router)
+	r := mux.NewRouter()
+	r.PathPrefix("/ws/").Handler(wsRouter)
 
 	// Serve Frontend routes
-	r := mux.NewRouter()
 	// For requests to dynamically generated game pages, serve index.html
 	r.PathPrefix("/game/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, filepath.Join(staticPath, indexPath))
@@ -65,7 +65,7 @@ func main() {
 	// TODO - Figure out how to serve styled 404 page for unhandled paths
 
 	// Run
-	if err := http.ListenAndServe(":"+appPort, router); err != nil {
+	if err := http.ListenAndServe(":"+appPort, r); err != nil {
 		log.Fatalf("Failed to run server: %v", err)
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
     environment:
       - REDIS_HOST=db
-      - MAX_CARDS=3
+      - MAX_CARDS=30
     ports:
       - "8080:8080"
     depends_on:

--- a/src/api/router.go
+++ b/src/api/router.go
@@ -3,6 +3,7 @@ package api
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/websocket"
 )
@@ -63,7 +64,7 @@ func (rt *WebSocketRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientGroup := r.URL.String()[1:]
+	clientGroup := strings.Split(r.URL.String(), "/ws/")[1]
 	client := NewClient(clientGroup, rt.pool, socket, rt.FindHandler)
 	rt.pool.Register <- client
 

--- a/ui/src/Socket.js
+++ b/ui/src/Socket.js
@@ -6,7 +6,7 @@ import {EventEmitter} from 'events';
 export default class Socket {
     constructor(id = "new-game") {
         console.log("New websocket!")
-        let ws = this.ws = new WebSocket(`ws://localhost:8080/${id}`);
+        let ws = this.ws = new WebSocket(`ws://localhost:8080/ws/${id}`);
         this.ee = new EventEmitter();
         // attach message function as event listener for incoming websocket messages.
         ws.onmessage = this.message.bind(this);


### PR DESCRIPTION
I assumed our issues in staging were caused by running a websocket connection through our K8s loadbalancer but I saw the same behavior locally when deploying the dockerized app to my local environment. 

This was a much sillier mistake... I had only been running the front and backend separately before so the React App wasn't actually being served from the go server... the issue in staging we saw happened because all traffic on the backend was accidentally being handled by the websocket router and that was not the intention. This should fix that (at least it does in the docker container in local-dev)
